### PR TITLE
Remove dependency on libcgroup-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+clsync (0.4.5-2) unstable; urgency=medium
+
+  * Remove dependency on libcgroup-dev
+
+ -- Dmitrii Okunev <xaionaro@gmail.com>  Wed, 17 Mar 2021 20:18:47 +0000
+
 clsync (0.4.5-1) unstable; urgency=medium
 
   [ Andrew Savchenko]

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Artyom A Anikeev <anikeev@ut.mephi.ru>
 Uploaders: Barak A. Pearlmutter <bap@debian.org>, Dmitry Yu Okunev <dyokunev@ut.mephi.ru>
 Build-Depends: debhelper-compat (= 13),
 	       libglib2.0-dev (>= 2.0.0),
-	       libcgroup-dev, libcap-dev
+	       libcap-dev
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: http://ut.mephi.ru/oss


### PR DESCRIPTION
`./configure` should automatically detect if the headers are reachable (and disable the features if not).

https://paste.ubuntu.com/p/G55ns3ZMNf/